### PR TITLE
Add push target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ BRANCH=`echo $$ELASTIC_VERSION | egrep --only-matching '^[0-9]+.[0-9]+'`
 
 all: elasticsearch logstash kibana beats
 
+push: elasticsearch-push logstash-push kibana-push beats-push
+
 submodules:
 	git submodule update --init --recursive
 	git submodule foreach git fetch --all
@@ -16,11 +18,23 @@ submodules:
 elasticsearch: submodules
 	make --directory=elasticsearch
 
+elasticsearch-push: elasticsearch
+	make push --directory=elasticsearch
+
 logstash: submodules
 	make --directory=logstash
+
+logstash-push: submodules
+	make push --directory=logstash
 
 kibana: submodules
 	make --directory=kibana
 
+kibana-push: submodules
+	make push --directory=kibana
+
 beats: submodules
 	make --directory=beats
+
+beats-push: submodules
+	make push --directory=beats


### PR DESCRIPTION
For the unified release we need to be able to trigger the individual
push targets for every submodule.

Add extra `push` target while leaving default behavior for `make`
unchanged.