### PR TITLE
Exposing APM Server on port outside stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     container_name: apm_server
     ports: ['127.0.0.1:8200:8200']
     networks: ['stack']
-    command: -e -E 'output.elasticsearch.password=${ELASTIC_PASSWORD}'
+    command: -e -E 'apm-server.host=0.0.0.0:8200'
     depends_on: ['elasticsearch','setup_apm_server']
 
   # Run a short-lived container to set up Logstash.
@@ -188,4 +188,6 @@ services:
     networks: ['stack']
     depends_on: ['elasticsearch','kibana']
 
-networks: {stack: {}}
+networks: 
+  stack:
+


### PR DESCRIPTION
Few changes here:
1.) Password is already in the setup script setup-beats.sh so it's not needed in the command for apm_server.
2.) In order to expose APM Server for demoing more than what's in the stack, 8200 needed to be exposed.  
3.) Removed the curly braces on the network standza as they're not really "Yaml'ish" 