### PR TITLE
Exposed apm-server to outside the box

### DIFF
--- a/config/apm-server/apm-server.yml
+++ b/config/apm-server/apm-server.yml
@@ -1,4 +1,5 @@
 apm-server.frontend.enabled: true
+apm-server.host: "0.0.0.0:8200"
 
 output.elasticsearch:
   hosts: ['elasticsearch:9200']


### PR DESCRIPTION
APM server cannot talk to outside world right now. Need it to be exposed to let real life APM agents talk to this installation.