### PR TITLE
Update setup.yml to override the ELASTIC_PASSWORD

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -6,6 +6,7 @@ services:
     cap_add: ['SYS_ADMIN']
     environment:
       - "PWD=${PWD}"
+      - "ELASTIC_PASSWORD"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "${PWD}:${PWD}"


### PR DESCRIPTION
If want to override the ELASTIC_PASSWORD it should be simple, not complex.
just run 
```ELASTIC_PASSWORD=changeme docker-compose -f setup.yml up```

closes #58