### PR TITLE
Pass version environment variables to setup

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -7,6 +7,8 @@ services:
     environment:
       - "PWD=${PWD}"
       - "ELASTIC_PASSWORD"
+      - "ELASTIC_VERSION"
+      - "TAG"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "${PWD}:${PWD}"


### PR DESCRIPTION
Pass `TAG` and `ELASTIC_VERSION` variables to the setup script to use
the specified versions.