### PR TITLE
Add -f flag so curl will fail when kibana states it's not ready

### DIFF
--- a/scripts/setup-beat.sh
+++ b/scripts/setup-beat.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 beat=$1
 
-until curl -s -k http://kibana:5601; do
+until curl -f -s -k http://kibana:5601; do
     echo "Waiting for kibana..."
     sleep 5
 done


### PR DESCRIPTION
tested and worked with 6.5.1 - Fixes #66

from the curl manpage:

       -f, --fail
              (HTTP) Fail silently (no output at all) on server errors. This is mostly done to better enable
              scripts etc to better deal with failed attempts. In normal cases when an HTTP server fails  to
              deliver a document, it returns an HTML document stating so (which often also describes why and
              more). This flag will prevent curl from outputting that and return error 22.

              This method is not fail-safe and there are occasions where non-successful response codes  will
              slip through, especially when authentication is involved (response codes 401 and 407).