### PR TITLE
Add setup script for 'apm-server'

### DIFF
--- a/docker-compose.setup.yml
+++ b/docker-compose.setup.yml
@@ -117,10 +117,11 @@ services:
     image: docker.elastic.co/apm/apm-server:${TAG}
     container_name: setup_apm_server
     user: root
-    command: ['/bin/bash', '-c', 'cat /usr/local/bin/setup-beat.sh | tr -d "\r" | bash -s apm-server']
+    command: ['/bin/bash', '-c', 'cat /usr/local/bin/setup-apm-server.sh | tr -d "\r" | bash']
+    working_dir: '/config'
     volumes:
       - './config:/config'
-      - './scripts/setup-beat.sh:/usr/local/bin/setup-beat.sh:ro'
+      - './scripts/setup-apm-server.sh:/usr/local/bin/setup-apm-server.sh:ro'
       - './config/apm-server/apm-server.yml:/usr/share/apm-server/apm-server.yml'
       - './config/ssl/ca/ca.crt:/usr/share/apm-server/certs/ca/ca.crt'
     environment: ['ELASTIC_PASSWORD=${ELASTIC_PASSWORD}']

--- a/docker-compose.setup.yml
+++ b/docker-compose.setup.yml
@@ -118,7 +118,6 @@ services:
     container_name: setup_apm_server
     user: root
     command: ['/bin/bash', '-c', 'cat /usr/local/bin/setup-apm-server.sh | tr -d "\r" | bash']
-    working_dir: '/config'
     volumes:
       - './config:/config'
       - './scripts/setup-apm-server.sh:/usr/local/bin/setup-apm-server.sh:ro'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,7 +230,7 @@ services:
       - source: ca.crt
         target: /usr/share/apm-server/certs/ca/ca.crt
     volumes:
-      - './scripts/setup-beat.sh:/usr/local/bin/setup-beat.sh:ro'
+      - './scripts/setup-apm-server.sh:/usr/local/bin/setup-apm-server.sh:ro'
     depends_on: ['elasticsearch', 'kibana']
     healthcheck:
       test: curl --cacert /usr/share/elasticsearch/config/certs/ca/ca.crt -s https://localhost:8200/healthcheck >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi

--- a/scripts/setup-apm-server.sh
+++ b/scripts/setup-apm-server.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cacert=/usr/share/apm-server/certs/ca/ca.crt
+# Wait for ca file to exist before we continue. If the ca file doesn't exist
+# then something went wrong.
+while [ ! -f $cacert ]
+do
+  sleep 2
+done
+ls -l $cacert
+
+es_url=https://elasticsearch:9200
+# Wait for Elasticsearch to start up before doing anything.
+while [[ "$(curl -u "elastic:${ELASTIC_PASSWORD}" --cacert $cacert -s -o /dev/null -w '%{http_code}' $es_url)" != "200" ]]; do 
+    sleep 5 
+done
+
+# Set the password for the apm_system user.
+# REF: https://www.elastic.co/guide/en/x-pack/6.0/setting-up-authentication.html#set-built-in-user-passwords
+until curl -u "elastic:${ELASTIC_PASSWORD}" --cacert $cacert -s -H 'Content-Type:application/json' \
+     -XPUT $es_url/_xpack/security/user/apm_system/_password \
+     -d "{\"password\": \"${ELASTIC_PASSWORD}\"}"
+do
+    sleep 2
+    echo Retrying...
+done
+
+
+echo "=== CREATE Keystore ==="
+if [ -f /config/apm-server/apm-server.keystore ]; then
+    echo "Remove old apm-server.keystore"
+    rm /config/apm-server/apm-server.keystore
+fi
+echo "y" | /usr/share/apm-server/apm-server keystore create
+echo "Setting ELASTIC_PASSWORD..."
+echo "$ELASTIC_PASSWORD" | /usr/share/apm-server/apm-server keystore add 'ELASTIC_PASSWORD' --stdin
+mv /usr/share/apm-server/config/apm-server.keystore /config/apm-server/apm-server.keystore

--- a/scripts/setup-beat.sh
+++ b/scripts/setup-beat.sh
@@ -6,7 +6,7 @@ beat=$1
 
 until curl -s "http://kibana:5601/login" | grep "Loading Kibana" > /dev/null; do
 	  echo "Waiting for kibana..."
-	  sleep 1
+	  sleep 5
 done
 
 chmod go-w /usr/share/$beat/$beat.yml


### PR DESCRIPTION
This creates a keystore for `apm-server`, and adds the `ELASTIC_PASSWORD` entry to it.
Also copies it into `/config/apm-server` so that it's available to the server.  

Resolves #73 