### PR TITLE
Fixing hanging issue - adding ulimits to elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
   kibana:
     image: docker.elastic.co/kibana/kibana:${TAG}


### PR DESCRIPTION
fixes https://github.com/elastic/stack-docker/issues/55
I have run `docker-compose -f setup.yml up` after this change, and it started working for me.

Solution based on:
https://github.com/docker-library/elasticsearch/issues/140
https://github.com/OpenCTI-Platform/opencti/issues/93
